### PR TITLE
Add prefixPath option

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -10,6 +10,7 @@ module.exports = {
     siteLanguage: `en`,
     themeColor: `#8257E6`,
     basePath: `/Haudy/`,
+    pathPrefix: `/Haudy/`,
   },
   plugins: [
     {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "gh-pages": "^3.2.3"
   },
   "scripts": {
-    "build": "gatsby build",
+    "build": "gatsby build --prefix-paths",
     "start": "gatsby develop",
-    "serve": "gatsby serve",
+    "serve": "gatsby serve --prefix-paths",
     "clean": "gatsby clean"
   },
   "repository": {


### PR DESCRIPTION
With this option and flags the local environment provided
by `npm run build` and `npm run serve` has it so,
that links in the sidebar do not result in 404.

Sadly this does not work for `npm run start`
as discussed in the corresponding issue:
https://github.com/gatsbyjs/gatsby/issues/3721