### PR TITLE
Only make self-declared members mandatory for documentation

### DIFF
--- a/docs/exercises/documentation.md
+++ b/docs/exercises/documentation.md
@@ -1,13 +1,13 @@
 # Dokumentation von Java-QuellCode
 
 !!! info "Information"
-    In der Softwareentwicklung ist es wichtig seinen Code ordentlich zu dokumentieren, damit es möglich ist diesen ohne viel Aufwand zu verstehen.
-    Dies hilft sowohl anderen, die mit Ihrem Code arbeiten oder ihn benutzten, sowohl auch Ihnen selber, wenn Sie länger nicht mehr mit diesen gearbeitet haben.
-    Die Dokumentation sollte dabei kurz erklären, was der Code macht und wie er zu benutzten ist.
+    In der Softwareentwicklung ist es wichtig, seinen Code ordentlich zu dokumentieren, damit es möglich ist, diesen ohne viel Aufwand zu verstehen.
+    Dies hilft sowohl anderen, die mit Ihrem Code arbeiten oder ihn benutzen, als auch Ihnen selber, wenn Sie länger nicht mehr mit diesem gearbeitet haben.
+    Die Dokumentation sollte dabei kurz erklären, was der Code macht und wie er zu benutzen ist.
     Es sollte aber nicht erklärt werden, wie genau der Code funktioniert, sondern dieser sollte als eine Blackbox, in welche man nicht genauer hineingucken kann, betrachtet werden.
 
-* In Java werden JavaDoc Kommentare als standardisierte Methode benutzt um Code zu dokumentieren.
-    * JAvaDoc Kommentare haben dabei den Vorteil, dass IDEs sie automatisch anzeigen können und HTML Seiten aus ihnen generiert werden können.
+* In Java werden JavaDoc Kommentare als standardisierte Methode benutzt, um Code zu dokumentieren.
+    * JavaDoc Kommentare haben dabei den Vorteil, dass IDEs sie automatisch anzeigen können und HTML Seiten aus ihnen generiert werden können.
 * Jeder JavaDoc Kommentar beginnt dabei mit **/\*\*** und endet mit **/\***.
   Jede neue Zeile beginnt mit einem **\***.
 * JavaDoc Kommentare werden direkt über die zugehörige Klasse, Methode, etc. geschrieben.
@@ -34,20 +34,20 @@
 
 ## Aufbau
 
-* Zu Beginn eines JavaDoc Kommentars steht allgemeine Beschreibung der Methode, welche auf alle Details der Methode eingeht und beschreibt was Sie bewirkt, wie Sie zu benutzten ist und was man dabei beachten muss.
+* Zu Beginn eines JavaDoc Kommentars steht eine allgemeine Beschreibung der Methode, welche auf alle Details der Methode eingeht und beschreibt was sie bewirkt, wie sie zu benutzten ist und was man dabei beachten muss.
 * Danach folgen sogenannte Tags, welche mit einem **@** und dem Namen des Tags beginnen.
 * Jeder JavaDoc Kommentar muss dabei, falls notwendig, folgenden Tags haben:
     * **@param Parametername** description Beschreibt kurz die Bedeutung des Parameters **Parametername**.
       Für jeden Parameter muss ein solcher Tag vorhanden sein.
     * **@return description** Beschreibt kurz die Bedeutung der Rückgabe der Methode.
       Wenn die Methode keine Rückgabe hat, wird dieser Tag weggelassen.
-    * **@throws Exceptionname description** Beschreibt kurz in welchen Fall die Exception **Exceptionname** geworfen wird.
+    * **@throws Exceptionname description** Beschreibt kurz, in welchem Fall die Exception **Exceptionname** geworfen wird. 
       Für jede Exception, welche in der throws-Klausel der Methode angegeben wird, muss ein solcher Tag vorhanden sein.
         * Optional können Sie diesen Tag auch für Runtimeexceptions hinzufügen, welche geworfen werden können.
 
 ## Verpflichtende Dokumentation
 
-* Ab dem dritten Übungsblatt kann es vorkommen, dass von Ihnen gefordert wird Ihren selbstgeschriebenen Code zu dokumentieren.
+* Ab dem dritten Übungsblatt kann es vorkommen, dass von Ihnen gefordert wird, Ihren selbstgeschriebenen Code zu dokumentieren.
   Wenn dies der Fall ist, müssen Sie alle von Ihnen geschriebenen Methoden, Konstruktoren, Klassen, Interfaces und Enums dokumentieren.
 
 ## Einige weitere Tags
@@ -56,7 +56,7 @@
 *  **@version version** Gibt die Version an.
   Kann nur in Klassen, Interface und Enums verwendet werden.
 *  **@since version** Gibt an, seit wann das Objekt verfügbar ist.
-*  **@see refernce** Erzeugt eine Referenz auf eine andere Dokumentation.
+*  **@see reference** Erzeugt eine Referenz auf eine andere Dokumentation.
 *  **@deprecated** Gibt an, dass die Methode veraltet ist und nicht verwendet werden sollte.
 *  Eine vollständige Liste finden Sie [hier].
 

--- a/docs/exercises/documentation.md
+++ b/docs/exercises/documentation.md
@@ -48,7 +48,7 @@
 ## Verpflichtende Dokumentation
 
 * Ab dem dritten Übungsblatt kann es vorkommen, dass von Ihnen gefordert wird, Ihren selbstgeschriebenen Code zu dokumentieren.
-  Wenn dies der Fall ist, müssen Sie alle von Ihnen geschriebenen Methoden, Konstruktoren, Klassen, Interfaces und Enums dokumentieren.
+  Wenn dies der Fall ist, müssen alle von Ihnen deklarierten Klassen, Interfaces, Enums und Methoden (inklusive Konstruktoren) mittels JavaDoc dokumentiert werden.
 
 ## Einige weitere Tags
 * **@author name** Gibt den Autor an.

--- a/docs/exercises/download-import-unsupported.md
+++ b/docs/exercises/download-import-unsupported.md
@@ -47,7 +47,7 @@
 
      * Importieren
      
-        * Sie können die Hausübungen entwerder importieren, indem Sie sich die zip Datei von Moodle herunterladen, entpacken und dann über **"File" -> "Import..." -> "Gradle" -> "Existing Gradle Project"** auswählen, oder über **"File" -> "Import..." -> "Git" -> "Projects from Git" -> "Clone URl"** die Daten des Git-Repositories eingeben.
+        * Sie können die Hausübungen entweder importieren, indem Sie sich die zip Datei von Moodle herunterladen, entpacken und dann über **"File" -> "Import..." -> "Gradle" -> "Existing Gradle Project"** auswählen, oder über **"File" -> "Import..." -> "Git" -> "Projects from Git" -> "Clone URl"** die Daten des Git-Repositories eingeben.
      
      * Gradle Tasks
     

--- a/docs/exercises/download-import.md
+++ b/docs/exercises/download-import.md
@@ -61,7 +61,7 @@ Diese erhalten sie entweder, indem sie das zugehörige [Git-Repository] klonen, 
         Wir empfehlen Ihnen für die Hausübungen Git zu verwenden.
     1. Alternativ können Sie auch mit der bereitgestellten Zip-Datei arbeiten. Laden Sie sich dafür aus dem Moodle Kurs die Zip-Datei der Vorlage für die entsprechende Hausübung herunter.
     2. Entpacken Sie die Zip-Datei und speichern Sie den entpackten Ordner an einem Ort Ihrer Wahl.
-        * Unter Windows können Sie Zip-Dateien entpacken, indem Sie im File Explorer einen Rechtklick auf die Datei machen und auf **"Alles extrahieren..."** drücken. Nachdem Sie     einen Speicherort angeben haben, müssen Sie noch auf **"extrahieren"** drücken, um die Datei zu entpacken.
+        * Unter Windows können Sie Zip-Dateien entpacken, indem Sie im File Explorer einen Rechtsklick auf die Datei machen und auf **"Alles extrahieren..."** drücken. Nachdem Sie     einen Speicherort angeben haben, müssen Sie noch auf **"extrahieren"** drücken, um die Datei zu entpacken.
         * Unter Mac OS können Sie Zip-Dateien entpacken, indem Sie im Finder einen Doppelklick auf diese machen.
     3. Gehen Sie nun in IntelliJ links oben im **"File"** Reiter auf **"open..."**
         * Wenn Sie IntelliJ das erste Mal öffnen, drücken Sie stattdessen rechts oben auf **"open"**

--- a/docs/exercises/edit.md
+++ b/docs/exercises/edit.md
@@ -133,7 +133,7 @@
           execution failed for task ':graderPublicRun'.
           There were failing tests.
 
-      * Die von uns zur Verfügung gestellten public-Tests laufen nicht erfolgreich durch. Um dies zu beheben, fixen Sie entweder den Fehler, den die Tessts aufzeigen, oder ändern Sie in der build.gradle.kts Datei direkt unter Ihren persönlichen Daten requirePublicTests von true auf false:
+      * Die von uns zur Verfügung gestellten public-Tests laufen nicht erfolgreich durch. Um dies zu beheben, fixen Sie entweder den Fehler, den die Tests aufzeigen, oder ändern Sie in der build.gradle.kts Datei direkt unter Ihren persönlichen Daten requirePublicTests von true auf false:
       ```
       requireGraderPublic = false
       ```
@@ -158,7 +158,7 @@
 
 
 !!! info "Information"
-    Wenn Sie Ihr Problem nicht selber beheben konnten, können Sie entweder auf unserem Discord Server im Channel **"\#techincal-issues"** oder im Moodle Forum für technische Fragen nachfragen. Fügen Sie bei beiden am besten einen Ausschnitt der Konsolenausgabe mit dem Fehler als Screenshot oder Text an.
+    Wenn Sie Ihr Problem nicht selber beheben konnten, können Sie entweder auf unserem Discord Server im Channel **"\#technical-issues"** oder im Moodle Forum für technische Fragen nachfragen. Fügen Sie bei beiden am besten einen Ausschnitt der Konsolenausgabe mit dem Fehler als Screenshot oder Text an.
 
 ## Den Debugger benutzten
 

--- a/docs/preparation/installation-intellij.md
+++ b/docs/preparation/installation-intellij.md
@@ -22,7 +22,7 @@
 
     === "AUR-Helper"
 
-        Falls Sie einen [AUR-Helper] installiert haben, könnnen Sie das Paket [intellij-idea-ce], bzw. [intellij-idea-ultimate-edition], installieren.
+        Falls Sie einen [AUR-Helper] installiert haben, können Sie das Paket [intellij-idea-ce], bzw. [intellij-idea-ultimate-edition], installieren.
 
     === "Manuell"
 

--- a/docs/preparation/installation-java.md
+++ b/docs/preparation/installation-java.md
@@ -22,7 +22,7 @@
        * Falls Ihnen bei der Ausgabe eine falsche Java Version oder ein Fehler angezeigt wird, überprüfen Sie wie folgt, ob Ihre Umgebungsvariablen korrekt gesetzt sind.
          1. Geben Sie in die Windowssuche (Win + S) **"Systemumgebungsvariablen bearbeiten"** ein und öffnen Sie das Fenster.
          2. Drücken Sie rechts unten auf **"Umgebungsvariablen"**.
-         3. Überprüfen Sie, ob in der unteren Liste eine Variable namens **"JAVA_HOME"** existiert und auf das Verzeichniss, in welchem Java 17 installiert ist, zeigt.
+         3. Überprüfen Sie, ob in der unteren Liste eine Variable namens **"JAVA_HOME"** existiert und auf das Verzeichnis, in welchem Java 17 installiert ist, zeigt.
              * Der Inhalt sollte in etwa wie folgt aussehen:
              ```
              C:\Program Files\Eclipse Adoptium\jdk-17.0.2.8-hotspot\


### PR DESCRIPTION
Sometimes we provide a class- or method-stub to the students and they have to implement it. This change makes it clear, that students do not have to provide JavaDoc to class-stubs, method-stubs or anything else that we provide to them. Only self-declared members (e.g. a method in a provided class-stub) has to be documented by them.

Also fixes some typos.