### PR TITLE
fix typo in javadoc explanation

### DIFF
--- a/docs/exercises/documentation.md
+++ b/docs/exercises/documentation.md
@@ -8,7 +8,7 @@
 
 * In Java werden JavaDoc Kommentare als standardisierte Methode benutzt um Code zu dokumentieren.
     * JAvaDoc Kommentare haben dabei den Vorteil, dass IDEs sie automatisch anzeigen können und HTML Seiten aus ihnen generiert werden können.
-* Jeder JavaDoc Kommentar beginnt dabei mit **/\*\*** und endet mit **/\***.
+* Jeder JavaDoc Kommentar beginnt dabei mit **/\*\*** und endet mit **\*/**.
   Jede neue Zeile beginnt mit einem **\***.
 * JavaDoc Kommentare werden direkt über die zugehörige Klasse, Methode, etc. geschrieben.
 * Wenn Sie in IntelliJ über einer über einer Methode, Klasse, etc. **/\*\*** schreiben und dann **Enter** drücken, wird automatisch eine Vorlage für Sie erstellt.


### PR DESCRIPTION
JavaDoc comments end with `*/` instead of `/*`.