### PR TITLE
Instructions: update jdk version for instaling java on debian

### DIFF
--- a/docs/preparation/installation-java.md
+++ b/docs/preparation/installation-java.md
@@ -53,7 +53,7 @@
             ```
             und
             ```
-            sudo apt install openjdk-17-jdk
+            sudo apt install openjdk-21-jdk
             ```
 
     === "Fedora"


### PR DESCRIPTION
Update jdk version for debian since `openjdk-17-jdk` is not in default trixie repos anymore.
This could also be done for fedora and arch, but they still have those packages in there official repos :shrug: 

